### PR TITLE
Image cache aaron

### DIFF
--- a/src/main/java/org/example/keystone/MainApplication.java
+++ b/src/main/java/org/example/keystone/MainApplication.java
@@ -30,6 +30,7 @@ public class MainApplication extends Application {
         FXMLLoader fxmlLoader = new FXMLLoader(MainApplication.class.getResource("hello-view.fxml")); // load fxml file
         Scene scene = new Scene(fxmlLoader.load(), 1920, 1080); // create new scene with loaded fxml
         stage.setTitle("Keystone");
+        scene.getStylesheets().add(getClass().getResource("dark-theme.css").toExternalForm());
         stage.setScene(scene);
         stage.show(); // display scene
     }

--- a/src/main/java/org/example/keystone/MainApplication.java
+++ b/src/main/java/org/example/keystone/MainApplication.java
@@ -25,7 +25,7 @@ public class MainApplication extends Application {
         pluginManager.loadPlugins();
         pluginManager.startPlugins();
         // ------------ GDAl -----------------
-
+        gdal.AllRegister();
         // ----------- Init UI -----------
         FXMLLoader fxmlLoader = new FXMLLoader(MainApplication.class.getResource("hello-view.fxml")); // load fxml file
         Scene scene = new Scene(fxmlLoader.load(), 1920, 1080); // create new scene with loaded fxml

--- a/src/main/java/org/example/keystone/api/ImageFactory.java
+++ b/src/main/java/org/example/keystone/api/ImageFactory.java
@@ -3,26 +3,35 @@ package org.example.keystone.api;
 import javafx.scene.image.Image;
 
 import java.io.File;
-import java.io.IOException;
 
 public class ImageFactory {
+    // 800 MB max memory cache, maybe can be adjusted by the user
+    private static final MemoryBoundImageCache cache = new MemoryBoundImageCache(800 * 1024 * 1024);
 
     public static Image getFXImage(File file) {
-
-        /*
-          This is just a factory class used to create a javafx Image object from a file. This handles all file types we are supporting
-          and consolidates the different logic into a single factory class. This will help reduce conditional logic on the front end.
-          Please use this factory class for loading ALL types of images.
-        */
-
         String fileExtension = MetadataDecoderFactory.getFileExtension(file);
 
         if (fileExtension == null) {
             throw new IllegalArgumentException("File extension error: null");
         }
+
         return switch (fileExtension) {
-            case "jpg", "png", "tif", "TIF", "ntf" -> ImageProcessor.isLargeImage(file) ? ImageProcessor.getSubsampledBufferedImage(file) : ImageProcessor.getBufferedImage(file);
+            case "jpg", "png", "tif", "TIF", "ntf" -> {
+                if (ImageProcessor.isLargeImage(file)) {
+
+                    Image cached = cache.get(file);
+                    if (cached != null) {
+                        yield cached;
+                    }
+                    Image subsampled = ImageProcessor.getSubsampledBufferedImage(file);
+                    cache.put(file, subsampled);
+                    yield subsampled;
+                } else {
+                    yield ImageProcessor.getBufferedImage(file);
+                }
+            }
             default -> throw new IllegalStateException("Unsupported file type: " + fileExtension);
         };
     }
 }
+

--- a/src/main/java/org/example/keystone/api/ImageFactory.java
+++ b/src/main/java/org/example/keystone/api/ImageFactory.java
@@ -5,18 +5,22 @@ import javafx.scene.image.Image;
 import java.io.File;
 
 public class ImageFactory {
+
+    private static long maxCacheCapacityInMB = 800;
     // 800 MB max memory cache, maybe can be adjusted by the user later
-    private static final MemoryBoundImageCache cache = new MemoryBoundImageCache(800 * 1024 * 1024);
+    private static MemoryBoundImageCache cache = new MemoryBoundImageCache(maxCacheCapacityInMB);
 
     public static Image getFXImage(File file) {
         String fileExtension = MetadataDecoderFactory.getFileExtension(file);
+        System.out.println(maxCacheCapacityInMB);
 
         if (fileExtension == null) {
             throw new IllegalArgumentException("File extension error: null");
         }
 
         return switch (fileExtension) {
-            case "jpg", "tif", "TIF", "ntf" -> {
+            case "jpg", "jpeg", "png", "tif", "TIF", "ntf" -> {
+                System.out.println(ImageProcessor.isLargeImage(file));
                 if (ImageProcessor.isLargeImage(file)) {
 
                     Image cached = cache.get(file);
@@ -30,11 +34,24 @@ public class ImageFactory {
                     yield ImageProcessor.getBufferedImage(file);
                 }
             }
-            case "png" -> {
-                yield ImageProcessor.getVectorBufferedImage(file);
-            }
             default -> throw new IllegalStateException("Unsupported file type: " + fileExtension);
         };
     }
+
+    public static long getMaxCacheCapacityInMB() {
+        System.out.println("[GET] maxCacheCapacityInMB = " + maxCacheCapacityInMB +
+                " | ClassLoader = " + ImageFactory.class.getClassLoader() +
+                " | Class = " + ImageFactory.class.hashCode());
+        return cache.getMaxBytes();
+    }
+
+    public static void setMaxCacheCapacityInMB(long size) {
+        ImageFactory.maxCacheCapacityInMB = size;
+        cache.setMaxBytes(size);
+        System.out.println("[SET] maxCacheCapacityInMB = " + maxCacheCapacityInMB +
+                " | ClassLoader = " + ImageFactory.class.getClassLoader() +
+                " | Class = " + ImageFactory.class.hashCode());
+    }
+
 }
 

--- a/src/main/java/org/example/keystone/api/ImageFactory.java
+++ b/src/main/java/org/example/keystone/api/ImageFactory.java
@@ -16,7 +16,7 @@ public class ImageFactory {
         }
 
         return switch (fileExtension) {
-            case "jpg", "png", "tif", "TIF", "ntf" -> {
+            case "jpg", "tif", "TIF", "ntf" -> {
                 if (ImageProcessor.isLargeImage(file)) {
 
                     Image cached = cache.get(file);
@@ -29,6 +29,9 @@ public class ImageFactory {
                 } else {
                     yield ImageProcessor.getBufferedImage(file);
                 }
+            }
+            case "png" -> {
+                yield ImageProcessor.getVectorBufferedImage(file);
             }
             default -> throw new IllegalStateException("Unsupported file type: " + fileExtension);
         };

--- a/src/main/java/org/example/keystone/api/ImageFactory.java
+++ b/src/main/java/org/example/keystone/api/ImageFactory.java
@@ -5,7 +5,7 @@ import javafx.scene.image.Image;
 import java.io.File;
 
 public class ImageFactory {
-    // 800 MB max memory cache, maybe can be adjusted by the user
+    // 800 MB max memory cache, maybe can be adjusted by the user later
     private static final MemoryBoundImageCache cache = new MemoryBoundImageCache(800 * 1024 * 1024);
 
     public static Image getFXImage(File file) {

--- a/src/main/java/org/example/keystone/api/ImageProcessor.java
+++ b/src/main/java/org/example/keystone/api/ImageProcessor.java
@@ -24,11 +24,11 @@ import org.gdal.gdal.Band;
 import org.gdal.gdal.Dataset;
 import org.gdal.gdal.gdal;
 import org.gdal.gdalconst.gdalconst;
+import org.gdal.gdalconst.gdalconstConstants;
 
 public class ImageProcessor {
 
    public static Image getBufferedImage(File file) {
-        gdal.AllRegister();
         Dataset dataset = gdal.Open(file.getAbsolutePath());
         if (dataset == null) {
             throw new RuntimeException("Failed to open file with GDAL: " + file.getAbsolutePath());
@@ -97,7 +97,6 @@ public class ImageProcessor {
 
     public static Image getSubsampledBufferedImage(File file) {
         int stepSize = getStepSize(file);
-        gdal.AllRegister();
         Dataset dataset = gdal.Open(file.getAbsolutePath());
         if (dataset == null) {
             throw new RuntimeException("Failed to open file with GDAL: " + file.getAbsolutePath());

--- a/src/main/java/org/example/keystone/api/ImageProcessor.java
+++ b/src/main/java/org/example/keystone/api/ImageProcessor.java
@@ -186,7 +186,7 @@ public class ImageProcessor {
    }
 
     public static int getStepSize(File file) {
-        long MAX_MEMORY_USAGE_BYTES = 300L * 1024 * 1024;
+        long MAX_MEMORY_USAGE_BYTES = 200L * 1024 * 1024;
         int BYTES_PER_PIXEL = 3;
 
         long fileSizeBytes = file.length();

--- a/src/main/java/org/example/keystone/api/MainApplicationController.java
+++ b/src/main/java/org/example/keystone/api/MainApplicationController.java
@@ -5,8 +5,10 @@ import javafx.application.Platform;
 import javafx.beans.property.StringProperty;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.control.*;
+import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.cell.TextFieldTreeCell;
@@ -17,8 +19,10 @@ import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.scene.input.MouseEvent;
 import javafx.stage.DirectoryChooser;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.util.StringConverter;
+import org.example.keystone.MainApplication;
 import org.gdal.gdal.XMLNode;
 import org.gdal.gdal.gdal;
 
@@ -26,11 +30,9 @@ import org.gdal.gdal.gdal;
 import java.awt.*;
 import java.beans.EventHandler;
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.Hashtable;
-import java.util.ResourceBundle;
-import java.util.Vector;
+import java.util.*;
 
 public class MainApplicationController implements Initializable {
 
@@ -227,5 +229,50 @@ public class MainApplicationController implements Initializable {
             }
         }
     }
+
+    public void openSettingsWindow() {
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/org/example/keystone/SettingsDialog.fxml"));
+
+            DialogPane settingsPane = loader.load(); // NEW instance
+            SettingsController controller = loader.getController();
+
+
+            // ✅ Manually set current values BEFORE showing
+            controller.cacheSizeField.setText(String.valueOf(ImageFactory.getMaxCacheCapacityInMB()));
+            controller.subsampleSizeField.setText(String.valueOf(ImageProcessor.getMaxSubsampledImageSizeInMB()));
+
+            Dialog<ButtonType> dialog = new Dialog<>();
+            dialog.setTitle("Settings");
+            dialog.setDialogPane(settingsPane);
+            dialog.initModality(Modality.APPLICATION_MODAL);
+
+
+            // Show the dialog and process result
+            Optional<ButtonType> result = dialog.showAndWait();
+            System.out.println("Dialog result: " + result);
+
+            if (result.isPresent() && result.get().getButtonData() == ButtonBar.ButtonData.OK_DONE) {
+                try {
+                    int cacheSize = Integer.parseInt(controller.cacheSizeField.getText());
+                    long subsampleSize = Long.parseLong(controller.subsampleSizeField.getText());
+
+                    ImageFactory.setMaxCacheCapacityInMB(cacheSize);
+                    ImageProcessor.setMaxSubsampledImageSizeInMB(subsampleSize);
+
+                } catch (NumberFormatException e) {
+                    e.printStackTrace();
+                    // Optional: show error alert
+                }
+            }
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+
+
 
 }

--- a/src/main/java/org/example/keystone/api/MemoryBoundImageCache.java
+++ b/src/main/java/org/example/keystone/api/MemoryBoundImageCache.java
@@ -5,7 +5,7 @@ import java.util.*;
 
 public class MemoryBoundImageCache {
     private final LinkedHashMap<File, javafx.scene.image.Image> cache;
-    private final long maxBytes;
+    private long maxBytes;
     private long currentBytes = 0;
 
     public MemoryBoundImageCache(long maxBytes) {
@@ -35,5 +35,13 @@ public class MemoryBoundImageCache {
     private long estimateImageSizeBytes(javafx.scene.image.Image image) {
         // image size estimation uses : width * height * 4 bytes per pixel
         return (long) image.getWidth() * (long) image.getHeight() * 4L;
+    }
+
+    public void setMaxBytes(long maxBytes) {
+        this.maxBytes = maxBytes;
+    }
+
+    public long getMaxBytes() {
+        return maxBytes;
     }
 }

--- a/src/main/java/org/example/keystone/api/MemoryBoundImageCache.java
+++ b/src/main/java/org/example/keystone/api/MemoryBoundImageCache.java
@@ -1,0 +1,39 @@
+package org.example.keystone.api;
+
+import java.io.File;
+import java.util.*;
+
+public class MemoryBoundImageCache {
+    private final LinkedHashMap<File, javafx.scene.image.Image> cache;
+    private final long maxBytes;
+    private long currentBytes = 0;
+
+    public MemoryBoundImageCache(long maxBytes) {
+        this.maxBytes = maxBytes;
+
+        this.cache = new LinkedHashMap<>(16, 0.75f, true);
+    }
+
+    public synchronized javafx.scene.image.Image get(File key) {
+        return cache.get(key);
+    }
+
+    public synchronized void put(File key, javafx.scene.image.Image image) {
+        long imageSize = estimateImageSizeBytes(image);
+
+        // check if there is space in the cache for the new image, and evict other images to make space if needed
+        while (!cache.isEmpty() && currentBytes + imageSize > maxBytes) {
+            Map.Entry<File, javafx.scene.image.Image> oldest = cache.entrySet().iterator().next();
+            currentBytes -= estimateImageSizeBytes(oldest.getValue());
+            cache.remove(oldest.getKey());
+        }
+
+        cache.put(key, image);
+        currentBytes += imageSize;
+    }
+
+    private long estimateImageSizeBytes(javafx.scene.image.Image image) {
+        // image size estimation uses : width * height * 4 bytes per pixel
+        return (long) image.getWidth() * (long) image.getHeight() * 4L;
+    }
+}

--- a/src/main/java/org/example/keystone/api/MetadataDecoder.java
+++ b/src/main/java/org/example/keystone/api/MetadataDecoder.java
@@ -42,7 +42,7 @@ public abstract class MetadataDecoder {
         }
 
         this.file = file;
-        getDataset();
+        this.dataset = dataset;
     }
 
     public Vector<String> getMetadata() {
@@ -406,6 +406,7 @@ public abstract class MetadataDecoder {
     }
 
     public void closeDataset() {
+        this.dataset.FlushCache();
         this.dataset.delete();
     }
 }

--- a/src/main/java/org/example/keystone/api/MetadataDecoderFactory.java
+++ b/src/main/java/org/example/keystone/api/MetadataDecoderFactory.java
@@ -21,8 +21,8 @@ public class MetadataDecoderFactory {
         return switch (fileType) {
             case "tif", "TIF" -> new TiffDecoder(file, getDataset(file, true));
             case "ntf" -> new NitfDecoder(file, getDataset(file, true));
-            case "jpg" -> new JpegDecoder(file, getDataset(file, false));
-            case "png" -> null;
+            case "jpg", "jpeg" -> new JpegDecoder(file, getDataset(file, false));
+            case "png" -> new PNGDecoder(file, getDataset(file, false));
             default -> throw new UnsupportedOperationException("Unsupported File Type: " + fileType);
         };
     }

--- a/src/main/java/org/example/keystone/api/PNGDecoder.java
+++ b/src/main/java/org/example/keystone/api/PNGDecoder.java
@@ -1,0 +1,45 @@
+package org.example.keystone.api;
+
+import org.gdal.gdal.Dataset;
+import org.gdal.osr.SpatialReference;
+
+import java.io.File;
+import java.util.Hashtable;
+
+public class PNGDecoder extends MetadataDecoder {
+
+    public PNGDecoder(File file, Dataset dataset) {
+        super(file, dataset);
+
+    }
+
+    @Override
+    public void setSpatialReference(SpatialReference srs) {
+
+    }
+
+    @Override
+    public void setSpatialReferenceFromWKT(String wktString) {
+
+    }
+
+    @Override
+    public void setMetadataField(String key, String value) {
+
+    }
+
+    @Override
+    public void setMetadataField(String key, String value, String domain) {
+
+    }
+
+    @Override
+    public void setMetadataFromHashTable(Hashtable<String, String> metadataHashTable) {
+
+    }
+
+    @Override
+    public void setMetadataFromHashTable(Hashtable<String, String> metadataHashTable, String domain) {
+
+    }
+}

--- a/src/main/java/org/example/keystone/api/SettingsController.java
+++ b/src/main/java/org/example/keystone/api/SettingsController.java
@@ -1,0 +1,27 @@
+package org.example.keystone.api;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.TextField;
+
+public class SettingsController {
+    @FXML
+    TextField cacheSizeField;
+
+    @FXML
+    TextField subsampleSizeField;
+
+    @FXML
+    public void initialize() {
+        cacheSizeField.textProperty().addListener((obs, oldVal, newVal) -> {
+            if (!newVal.matches("\\d*")) {
+                cacheSizeField.setText(newVal.replaceAll("[^\\d]", ""));
+            }
+        });
+
+        subsampleSizeField.textProperty().addListener((obs, oldVal, newVal) -> {
+            if (!newVal.matches("\\d*")) {
+                subsampleSizeField.setText(newVal.replaceAll("[^\\d]", ""));
+            }
+        });
+    }
+}

--- a/src/main/java/org/example/keystone/api/TiffDecoder.java
+++ b/src/main/java/org/example/keystone/api/TiffDecoder.java
@@ -39,6 +39,10 @@ public class TiffDecoder extends MetadataDecoder {
             Writes a single key-value pair to the file metadata under the default metadata domain
          */
         this.dataset.SetMetadataItem(key.toUpperCase(), value);
+        this.dataset.FlushCache();
+        this.dataset.delete();
+        this.dataset = null;
+        this.getDataset();
     }
 
     public void setMetadataField(String key, String value, String domain) {

--- a/src/main/resources/org/example/keystone/SettingsDialog.fxml
+++ b/src/main/resources/org/example/keystone/SettingsDialog.fxml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<DialogPane xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.example.keystone.api.SettingsController">
+    <content>
+        <GridPane hgap="10" vgap="10">
+            <Label text="Image Cache Size (MB):" GridPane.rowIndex="0" GridPane.columnIndex="0"/>
+            <TextField fx:id="cacheSizeField" GridPane.rowIndex="0" GridPane.columnIndex="1"/>
+
+            <Label text="Max Image Size (MB):" GridPane.rowIndex="1" GridPane.columnIndex="0"/>
+            <TextField fx:id="subsampleSizeField" GridPane.rowIndex="1" GridPane.columnIndex="1"/>
+        </GridPane>
+    </content>
+    <buttonTypes>
+        <ButtonType text="Apply" buttonData="OK_DONE"/>
+        <ButtonType text="Cancel" buttonData="CANCEL_CLOSE"/>
+    </buttonTypes>
+</DialogPane>

--- a/src/main/resources/org/example/keystone/dark-theme.css
+++ b/src/main/resources/org/example/keystone/dark-theme.css
@@ -1,0 +1,58 @@
+.root {
+    -fx-base: #2b2b2b;
+    -fx-background: #2b2b2b;
+    -fx-control-inner-background: #3c3f41;
+    -fx-text-fill: #dcdcdc;
+    -fx-accent: #6897bb;
+    -fx-focus-color: #6897bb;
+    -fx-faint-focus-color: transparent;
+}
+
+.label, .menu, .menu-bar, .menu-item, .tab, .tree-cell, .tree-table-row-cell {
+    -fx-background-color: transparent;
+    -fx-text-fill: #dcdcdc;
+}
+
+.menu-bar {
+    -fx-background-color: #3c3f41;
+}
+
+.tab-pane {
+    -fx-tab-background-color: #3c3f41;
+    -fx-background-color: #2b2b2b;
+}
+
+.tab {
+    -fx-background-color: #3c3f41;
+    -fx-text-base-color: #dcdcdc;
+}
+
+.tree-table-view {
+    -fx-table-cell-border-color: #4e4e4e;
+    -fx-control-inner-background: #2b2b2b;
+}
+
+.dialog-pane {
+    -fx-background-color: #2b2b2b;
+}
+
+.dialog-pane > *.button-bar > *.button {
+    -fx-background-color: #3c3f41;
+    -fx-text-fill: #dcdcdc;
+}
+
+.dialog-pane .content.label {
+    -fx-text-fill: #dcdcdc;
+}
+
+.label {
+    -fx-text-fill: #dcdcdc;
+}
+
+.text-field {
+    -fx-background-color: #3c3f41;
+    -fx-text-fill: #dcdcdc;
+    -fx-highlight-fill: #6897bb;
+    -fx-highlight-text-fill: #000000;
+    -fx-prompt-text-fill: #888888;
+}

--- a/src/main/resources/org/example/keystone/hello-view.fxml
+++ b/src/main/resources/org/example/keystone/hello-view.fxml
@@ -80,14 +80,19 @@
                    <content>
                        <AnchorPane fx:id="imagePreviewAnchorPane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
                            <children>
-                               <ImageView fx:id="imageViewer" fitHeight="1025.0" fitWidth="668.0" pickOnBounds="true" preserveRatio="true">
-                                   <cursor>
-                                       <Cursor fx:constant="DEFAULT" />
-                                   </cursor>
-                                   <viewport>
-                                       <Rectangle2D />
-                                   </viewport>
-                               </ImageView>
+                              <StackPane prefHeight="1025.0" prefWidth="955.0">
+                                 <children>
+                                     <ImageView fx:id="imageViewer" fitHeight="1025.0" fitWidth="668.0" pickOnBounds="true" preserveRatio="true">
+                                         <cursor>
+                                             <Cursor fx:constant="DEFAULT" />
+                                         </cursor>
+                                         <viewport>
+                                             <Rectangle2D />
+                                         </viewport>
+                                     </ImageView>
+                                     <ProgressIndicator fx:id="loadingSpinner" visible="false" />
+                                 </children>
+                              </StackPane>
                            </children>
                        </AnchorPane>
                    </content>

--- a/src/main/resources/org/example/keystone/hello-view.fxml
+++ b/src/main/resources/org/example/keystone/hello-view.fxml
@@ -34,6 +34,10 @@
           </Menu>
             <Menu mnemonicParsing="false" text="Tools" />
             <Menu mnemonicParsing="false" text="Options">
+                <items>
+                    <SeparatorMenuItem mnemonicParsing="flase" />
+                        <MenuItem mnemonicParsing="false" text="Settings" onAction="#openSettingsWindow"/>
+                </items>
               <items>
                   <CheckMenuItem mnemonicParsing="false" text="Verbose" />
                   <CheckMenuItem mnemonicParsing="false" text="Disable Warnings" />


### PR DESCRIPTION
Added loading spinner while images are loading, and added StackPane to center contents of the ImagePane.

Also added memory-bound caching for subsampled images so they don't need to be re-subsampled every time they are viewed (unless the cached image was evicted from the cache)